### PR TITLE
Made BkImageSurface compatible with SVG data URI images

### DIFF
--- a/BkImageSurface.js
+++ b/BkImageSurface.js
@@ -97,12 +97,9 @@ define(function(require, exports, module) {
         var props = this.getProperties();
         if (this._imageUrl) {
             var imageUrl = this._imageUrl;
-            // url encode '(' and ')'
-            if ((imageUrl.indexOf('(') >= 0) || (imageUrl.indexOf(')') >= 0)) {
-                imageUrl = imageUrl.split('(').join('%28');
-                imageUrl = imageUrl.split(')').join('%29');
-            }
-            props.backgroundImage = 'url(' + imageUrl + ')';
+            // replace single quotes to prevent string conflicts in css
+            imageUrl.replace(/'/g, '"');
+            props.backgroundImage = 'url(\'' + imageUrl + '\')';
         }
         else {
             props.backgroundImage = '';


### PR DESCRIPTION
The previous method of escaping ( and ) characters broke unencoded inline SVG data URIs. Replaced with having single quotes in the url() statement, and replacing any single quotes with doubles in the SVG data.

Use case example:

``` javascript
new BkImageSurface({
  content: "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='10'><linearGradient id='gradient'><stop offset='10%' stop-color='%23F00'/><stop offset='90%' stop-color='%23fcc'/> </linearGradient><rect fill='url(%23gradient)' x='0' y='0' width='100%' height='100%'/></svg>"
});
```
